### PR TITLE
Allow native errors from exit codes to throw properly

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -23,6 +23,7 @@ namespace System.Management.Automation
         internal const string EngineSource = "PSEngine";
         internal const string PSAnsiProgressFeatureName = "PSAnsiProgress";
         internal const string PSNativeCommandArgumentPassingFeatureName = "PSNativeCommandArgumentPassing";
+        internal const string PSNativeCommandErrorActionPreferenceFeatureName = "PSNativeCommandErrorActionPreference";
 
         #endregion
 
@@ -140,6 +141,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSLoadAssemblyFromNativeCode",
                     description: "Expose an API to allow assembly loading from native code"),
+                new ExperimentalFeature(
+                    name: PSNativeCommandErrorActionPreferenceFeatureName,
+                    description: "Native commands with non-zero exit codes issue errors according to $ErrorActionPreference when $PSNativeCommandUseErrorActionPreference is $true"),
             };
 
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4470,155 +4470,169 @@ end {
         internal const bool DefaultWhatIfPreference = false;
         internal const ConfirmImpact DefaultConfirmPreference = ConfirmImpact.High;
 
-        internal static readonly SessionStateVariableEntry[] BuiltInVariables = new SessionStateVariableEntry[]
+        static InitialSessionState()
         {
-            // Engine variables that should be precreated before running profile
-            // Bug fix for Win7:2202228 Engine halts if initial command fulls up variable table
-            // Anytime a new variable that the engine depends on to run is added, this table
-            // must be updated...
-            new SessionStateVariableEntry(SpecialVariables.LastToken, null, string.Empty),
-            new SessionStateVariableEntry(SpecialVariables.FirstToken, null, string.Empty),
-            new SessionStateVariableEntry(SpecialVariables.StackTrace, null, string.Empty),
+            var builtinVariables = new List<SessionStateVariableEntry>()
+            {
+                // Engine variables that should be precreated before running profile
+                // Bug fix for Win7:2202228 Engine halts if initial command fulls up variable table
+                // Anytime a new variable that the engine depends on to run is added, this table
+                // must be updated...
+                new SessionStateVariableEntry(SpecialVariables.LastToken, null, string.Empty),
+                new SessionStateVariableEntry(SpecialVariables.FirstToken, null, string.Empty),
+                new SessionStateVariableEntry(SpecialVariables.StackTrace, null, string.Empty),
 
-            // Variable which controls the output rendering
-            new SessionStateVariableEntry(
-                SpecialVariables.PSStyle,
-                PSStyle.Instance,
-                RunspaceInit.PSStyleDescription,
-                ScopedItemOptions.None),
+                // Variable which controls the output rendering
+                new SessionStateVariableEntry(
+                    SpecialVariables.PSStyle,
+                    PSStyle.Instance,
+                    RunspaceInit.PSStyleDescription,
+                    ScopedItemOptions.None),
 
-            // Variable which controls the encoding for piping data to a NativeCommand
-            new SessionStateVariableEntry(
-                SpecialVariables.OutputEncoding,
-                Utils.utf8NoBom,
-                RunspaceInit.OutputEncodingDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(System.Text.Encoding))),
+                // Variable which controls the encoding for piping data to a NativeCommand
+                new SessionStateVariableEntry(
+                    SpecialVariables.OutputEncoding,
+                    Utils.utf8NoBom,
+                    RunspaceInit.OutputEncodingDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(System.Text.Encoding))),
 
-            // Preferences
-            //
-            // NTRAID#Windows Out Of Band Releases-931461-2006/03/13
-            // ArgumentTypeConverterAttribute is applied to these variables,
-            // but this only reaches the global variable.  If these are
-            // redefined in script scope etc, the type conversion
-            // is not applicable.
-            //
-            // Variables typed to ActionPreference
-            new SessionStateVariableEntry(
-                SpecialVariables.ConfirmPreference,
-                DefaultConfirmPreference,
-                RunspaceInit.ConfirmPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ConfirmImpact))),
-            new SessionStateVariableEntry(
-                SpecialVariables.DebugPreference,
-                DefaultDebugPreference,
-                RunspaceInit.DebugPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.ErrorActionPreference,
-                DefaultErrorActionPreference,
-                RunspaceInit.ErrorActionPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.ProgressPreference,
-                DefaultProgressPreference,
-                RunspaceInit.ProgressPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.VerbosePreference,
-                DefaultVerbosePreference,
-                RunspaceInit.VerbosePreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.WarningPreference,
-                DefaultWarningPreference,
-                RunspaceInit.WarningPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.InformationPreference,
-                DefaultInformationPreference,
-                RunspaceInit.InformationPreferenceDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
-            new SessionStateVariableEntry(
-                SpecialVariables.ErrorView,
-                DefaultErrorView,
-                RunspaceInit.ErrorViewDescription,
-                ScopedItemOptions.None,
-                new ArgumentTypeConverterAttribute(typeof(ErrorView))),
-            new SessionStateVariableEntry(
-                SpecialVariables.NestedPromptLevel,
-                0,
-                RunspaceInit.NestedPromptLevelDescription),
-            new SessionStateVariableEntry(
-                SpecialVariables.PSNativeCommandUseErrorActionPreference,
-                DefaultPSNativeCommandUseErrorActionPreference,
-                RunspaceInit.PSNativeCommandUseErrorActionPreferenceDescription),
-            new SessionStateVariableEntry(
-                SpecialVariables.WhatIfPreference,
-                DefaultWhatIfPreference,
-                RunspaceInit.WhatIfPreferenceDescription),
-            new SessionStateVariableEntry(
-                FormatEnumerationLimit,
-                DefaultFormatEnumerationLimit,
-                RunspaceInit.FormatEnumerationLimitDescription),
+                // Preferences
+                //
+                // NTRAID#Windows Out Of Band Releases-931461-2006/03/13
+                // ArgumentTypeConverterAttribute is applied to these variables,
+                // but this only reaches the global variable.  If these are
+                // redefined in script scope etc, the type conversion
+                // is not applicable.
+                //
+                // Variables typed to ActionPreference
+                new SessionStateVariableEntry(
+                    SpecialVariables.ConfirmPreference,
+                    DefaultConfirmPreference,
+                    RunspaceInit.ConfirmPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ConfirmImpact))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.DebugPreference,
+                    DefaultDebugPreference,
+                    RunspaceInit.DebugPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.ErrorActionPreference,
+                    DefaultErrorActionPreference,
+                    RunspaceInit.ErrorActionPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.ProgressPreference,
+                    DefaultProgressPreference,
+                    RunspaceInit.ProgressPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.VerbosePreference,
+                    DefaultVerbosePreference,
+                    RunspaceInit.VerbosePreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.WarningPreference,
+                    DefaultWarningPreference,
+                    RunspaceInit.WarningPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.InformationPreference,
+                    DefaultInformationPreference,
+                    RunspaceInit.InformationPreferenceDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ActionPreference))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.ErrorView,
+                    DefaultErrorView,
+                    RunspaceInit.ErrorViewDescription,
+                    ScopedItemOptions.None,
+                    new ArgumentTypeConverterAttribute(typeof(ErrorView))),
+                new SessionStateVariableEntry(
+                    SpecialVariables.NestedPromptLevel,
+                    0,
+                    RunspaceInit.NestedPromptLevelDescription),
+                new SessionStateVariableEntry(
+                    SpecialVariables.WhatIfPreference,
+                    DefaultWhatIfPreference,
+                    RunspaceInit.WhatIfPreferenceDescription),
+                new SessionStateVariableEntry(
+                    FormatEnumerationLimit,
+                    DefaultFormatEnumerationLimit,
+                    RunspaceInit.FormatEnumerationLimitDescription),
 
-             // variable for PSEmailServer
-            new SessionStateVariableEntry(
-                SpecialVariables.PSEmailServer,
-                string.Empty,
-                RunspaceInit.PSEmailServerDescription),
+                // variable for PSEmailServer
+                new SessionStateVariableEntry(
+                    SpecialVariables.PSEmailServer,
+                    string.Empty,
+                    RunspaceInit.PSEmailServerDescription),
 
-            // Start: Variables which control remoting behavior
-            new SessionStateVariableEntry(
-                Microsoft.PowerShell.Commands.PSRemotingBaseCmdlet.DEFAULT_SESSION_OPTION,
-                new System.Management.Automation.Remoting.PSSessionOption(),
-                RemotingErrorIdStrings.PSDefaultSessionOptionDescription,
-                ScopedItemOptions.None),
-            new SessionStateVariableEntry(
-                SpecialVariables.PSSessionConfigurationName,
-                "http://schemas.microsoft.com/powershell/Microsoft.PowerShell",
-                RemotingErrorIdStrings.PSSessionConfigurationName,
-                ScopedItemOptions.None),
-            new SessionStateVariableEntry(
-                SpecialVariables.PSSessionApplicationName,
-                "wsman",
-                RemotingErrorIdStrings.PSSessionAppName,
-                ScopedItemOptions.None),
-            // End: Variables which control remoting behavior
+                // Start: Variables which control remoting behavior
+                new SessionStateVariableEntry(
+                    Microsoft.PowerShell.Commands.PSRemotingBaseCmdlet.DEFAULT_SESSION_OPTION,
+                    new System.Management.Automation.Remoting.PSSessionOption(),
+                    RemotingErrorIdStrings.PSDefaultSessionOptionDescription,
+                    ScopedItemOptions.None),
+                new SessionStateVariableEntry(
+                    SpecialVariables.PSSessionConfigurationName,
+                    "http://schemas.microsoft.com/powershell/Microsoft.PowerShell",
+                    RemotingErrorIdStrings.PSSessionConfigurationName,
+                    ScopedItemOptions.None),
+                new SessionStateVariableEntry(
+                    SpecialVariables.PSSessionApplicationName,
+                    "wsman",
+                    RemotingErrorIdStrings.PSSessionAppName,
+                    ScopedItemOptions.None),
+                // End: Variables which control remoting behavior
 
-            #region Platform
-            new SessionStateVariableEntry(
-                SpecialVariables.IsLinux,
-                Platform.IsLinux,
-                string.Empty,
-                ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                #region Platform
+                new SessionStateVariableEntry(
+                    SpecialVariables.IsLinux,
+                    Platform.IsLinux,
+                    string.Empty,
+                    ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 
-            new SessionStateVariableEntry(
-                SpecialVariables.IsMacOS,
-                Platform.IsMacOS,
-                string.Empty,
-                ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                new SessionStateVariableEntry(
+                    SpecialVariables.IsMacOS,
+                    Platform.IsMacOS,
+                    string.Empty,
+                    ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 
-            new SessionStateVariableEntry(
-                SpecialVariables.IsWindows,
-                Platform.IsWindows,
-                string.Empty,
-                ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                new SessionStateVariableEntry(
+                    SpecialVariables.IsWindows,
+                    Platform.IsWindows,
+                    string.Empty,
+                    ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 
-            new SessionStateVariableEntry(
-                SpecialVariables.IsCoreCLR,
-                Platform.IsCoreCLR,
-                string.Empty,
-                ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
-            #endregion
-        };
+                new SessionStateVariableEntry(
+                    SpecialVariables.IsCoreCLR,
+                    Platform.IsCoreCLR,
+                    string.Empty,
+                    ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                #endregion
+            };
+
+            if (ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName))
+            {
+                builtinVariables.Add(
+                    new SessionStateVariableEntry(
+                        SpecialVariables.PSNativeCommandUseErrorActionPreference,
+                        DefaultPSNativeCommandUseErrorActionPreference,
+                        RunspaceInit.PSNativeCommandUseErrorActionPreferenceDescription,
+                        ScopedItemOptions.None,
+                        new ArgumentTypeConverterAttribute(typeof(bool))));
+            }
+
+            BuiltInVariables = builtinVariables.ToArray();
+        }
+
+        internal static readonly SessionStateVariableEntry[] BuiltInVariables;
 
         /// <summary>
         /// Returns a new array of alias entries everytime it's called. This

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2819,7 +2819,7 @@ namespace System.Management.Automation
         /// but the command failure will ultimately be
         /// <see cref="System.Management.Automation.ActionPreferenceStopException"/>,
         /// </remarks>
-        internal void _WriteErrorSkipAllowCheck(ErrorRecord errorRecord, ActionPreference? actionPreference = null, bool isNativeError = false)
+        internal void _WriteErrorSkipAllowCheck(ErrorRecord errorRecord, ActionPreference? actionPreference = null, bool isNativeStdErrCall = false)
         {
             ThrowIfStopping();
 
@@ -2839,7 +2839,7 @@ namespace System.Management.Automation
                 this.PipelineProcessor.LogExecutionError(_thisCommand.MyInvocation, errorRecord);
             }
 
-            if (!(ExperimentalFeature.IsEnabled("PSNotApplyErrorActionToStderr") && isNativeError))
+            if (!(ExperimentalFeature.IsEnabled("PSNotApplyErrorActionToStderr") && isNativeStdErrCall))
             {
                 this.PipelineProcessor.ExecutionFailed = true;
 
@@ -2905,7 +2905,7 @@ namespace System.Management.Automation
             // when tracing), so don't add the member again.
 
             // We don't add a note property on messages that comes from stderr stream.
-            if (!isNativeError)
+            if (!isNativeStdErrCall)
             {
                 errorWrap.WriteStream = WriteStreamType.Error;
             }

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -877,7 +877,7 @@ namespace System.Management.Automation
                                 errorId);
 
                         var errorRecord = new ErrorRecord(exception, errorId, ErrorCategory.NotSpecified, null);
-                        this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord, isNativeError: true);
+                        this.commandRuntime._WriteErrorSkipAllowCheck(errorRecord);
                     }
                 }
             }
@@ -1202,7 +1202,7 @@ namespace System.Management.Automation
                 ErrorRecord record = outputValue.Data as ErrorRecord;
                 Dbg.Assert(record != null, "ProcessReader should ensure that data is ErrorRecord");
                 record.SetInvocationInfo(this.Command.MyInvocation);
-                this.commandRuntime._WriteErrorSkipAllowCheck(record, isNativeError: true);
+                this.commandRuntime._WriteErrorSkipAllowCheck(record, isNativeStdErrCall: true);
             }
             else if (outputValue.Stream == MinishellStream.Output)
             {

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -136,7 +136,7 @@ namespace System.Management.Automation
     /// when a native command retuns a non-zero exit code.
     /// </summary>
     [Serializable]
-    public class NativeCommandException : RuntimeException
+    public class NativeCommandExitException : RuntimeException
     {
         /// <summary>
         /// Gets the path of the native command.
@@ -156,7 +156,7 @@ namespace System.Management.Automation
         #region Constructors
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with information on the native
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with information on the native
         /// command, a specified error message and a specified error ID.
         /// </summary>
         /// <param name="path">The full path of the native command.</param>
@@ -164,31 +164,31 @@ namespace System.Management.Automation
         /// <param name="processId">The process ID of the process before it ended.</param>
         /// <param name="message">The error message.</param>
         /// <param name="errorId">The error ID.</param>
-        internal NativeCommandException(string path, int exitCode, int processId, string message, string errorId)
+        internal NativeCommandExitException(string path, int exitCode, int processId, string message, string errorId)
             : base(message)
         {
             SetErrorId(errorId);
             SetErrorCategory(ErrorCategory.NotSpecified);
-            this.Path = path;
-            this.ExitCode = exitCode;
-            this.ProcessId = processId;
+            Path = path;
+            ExitCode = exitCode;
+            ProcessId = processId;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class.
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class.
         /// </summary>
-        public NativeCommandException() : base() { }
+        public NativeCommandExitException() : base() { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message.
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with a specified error message.
         /// </summary>
         /// <param name="message">
         /// A localized error message.
         /// </param>
-        public NativeCommandException(string message) : base(message) { }
+        public NativeCommandExitException(string message) : base(message) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with a specified error message
         /// and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">
@@ -197,14 +197,14 @@ namespace System.Management.Automation
         /// <param name="innerException">
         /// Inner exception.
         /// </param>
-        public NativeCommandException(string message, Exception innerException) : base(message, innerException) { }
+        public NativeCommandExitException(string message, Exception innerException) : base(message, innerException) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with serialized data.
+        /// Initializes a new instance of the <see cref="NativeCommandExitException"/> class with serialized data.
         /// </summary>
         /// <param name="info"></param>
         /// <param name="context"></param>
-        protected NativeCommandException(SerializationInfo info, StreamingContext context)
+        protected NativeCommandExitException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             if (info == null)
@@ -212,9 +212,9 @@ namespace System.Management.Automation
                 throw new PSArgumentNullException(nameof(info));
             }
 
-            this.Path = info.GetString(nameof(this.Path));
-            this.ExitCode = info.GetInt32(nameof(this.ExitCode));
-            this.ProcessId = info.GetInt32(nameof(this.ProcessId));
+            Path = info.GetString(nameof(Path));
+            ExitCode = info.GetInt32(nameof(ExitCode));
+            ProcessId = info.GetInt32(nameof(ProcessId));
         }
 
         #endregion Constructors
@@ -233,9 +233,9 @@ namespace System.Management.Automation
 
             base.GetObjectData(info, context);
 
-            info.AddValue(nameof(this.Path), this.Path);
-            info.AddValue(nameof(this.ExitCode), this.ExitCode);
-            info.AddValue(nameof(this.ProcessId), this.ProcessId);
+            info.AddValue(nameof(Path), Path);
+            info.AddValue(nameof(ExitCode), ExitCode);
+            info.AddValue(nameof(ProcessId), ProcessId);
         }
     }
 
@@ -869,7 +869,7 @@ namespace System.Management.Automation
                                 _nativeProcess.ExitCode);
 
                         var exception =
-                            new NativeCommandException(
+                            new NativeCommandExitException(
                                 this.Path,
                                 _nativeProcess.ExitCode,
                                 _nativeProcess.Id,

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -188,7 +188,7 @@ namespace System.Management.Automation
         public NativeCommandException(string message) : base(message) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message 
+        /// Initializes a new instance of the <see cref="NativeCommandException"/> class with a specified error message
         /// and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">
@@ -841,8 +841,8 @@ namespace System.Management.Automation
 
                     this.commandRuntime.PipelineProcessor.ExecutionFailed = true;
 
-                    bool nativeCommandUseErrorActionPreference = 
-                        this.Command.Context.GetBooleanPreference(
+                    bool nativeCommandUseErrorActionPreference = ExperimentalFeature.IsEnabled(ExperimentalFeature.PSNativeCommandErrorActionPreferenceFeatureName)
+                        && this.Command.Context.GetBooleanPreference(
                             SpecialVariables.PSNativeCommandUseErrorActionPreferenceVarPath,
                             InitialSessionState.DefaultPSNativeCommandUseErrorActionPreference,
                             out _);
@@ -870,7 +870,7 @@ namespace System.Management.Automation
 
                         var exception =
                             new NativeCommandException(
-                                this.Path, 
+                                this.Path,
                                 _nativeProcess.ExitCode,
                                 _nativeProcess.Id,
                                 errorMsg,

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -326,7 +326,7 @@ namespace System.Management.Automation
                                                                    /* PSCommandPath */     typeof(string),
                                                                  };
 
-        internal static readonly string[] PreferenceVariables = 
+        internal static readonly string[] PreferenceVariables =
         {
             SpecialVariables.DebugPreference,
             SpecialVariables.VerbosePreference,
@@ -338,7 +338,7 @@ namespace System.Management.Automation
             SpecialVariables.PSNativeCommandUseErrorActionPreference,
         };
 
-        internal static readonly Type[] PreferenceVariableTypes = 
+        internal static readonly Type[] PreferenceVariableTypes =
         {
             /* DebugPreference */                         typeof(ActionPreference),
             /* VerbosePreference */                       typeof(ActionPreference),

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -188,7 +188,7 @@
   </data>
   <data name="PSNativeCommandUseErrorActionPreferenceDescription" xml:space="preserve">
     <value>If true, $ErrorActionPreference applies to native executable non-zero exit codes</value>
-  </data>  
+  </data>
   <data name="WhatIfPreferenceDescription" xml:space="preserve">
     <value>If true, WhatIf is considered to be enabled for all commands.</value>
   </data>

--- a/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
+++ b/test/powershell/engine/Basic/NativeCommandErrorHandling.Tests.ps1
@@ -6,6 +6,12 @@
 
 Describe 'Native command error handling tests' -Tags 'CI' {
     BeforeAll {
+        if (-not [ExperimentalFeature]::IsEnabled('PSNativeCommandErrorActionPreference'))
+        {
+            $PSDefaultParameterValues['It:Skip'] = $true
+            return
+        }
+
         $exeName = $IsWindows ? 'testexe.exe' : 'testexe'
 
         $errorActionPrefTestCases = @(
@@ -14,6 +20,10 @@ Describe 'Native command error handling tests' -Tags 'CI' {
             @{ ErrorActionPref = 'SilentlyContinue' }
             @{ ErrorActionPref = 'Ignore' }
         )
+    }
+
+    AfterAll {
+        $PSDefaultParameterValues['It:Skip'] = $false
     }
 
     BeforeEach {


### PR DESCRIPTION
Modify the native error parameter in the `_WriteErrorSkipAllowCheck()` method to allow native errors to throw properly